### PR TITLE
Made validateFuntion optional

### DIFF
--- a/src/Plugin.Maui.OCR/Abstractions/IOcrService.cs
+++ b/src/Plugin.Maui.OCR/Abstractions/IOcrService.cs
@@ -95,7 +95,7 @@ public static class OcrPatternMatcher
         var regex = new Regex(config.RegexPattern);
         var match = regex.Match(input);
 
-        if (match.Success && config.ValidationFunction(match.Value))
+        if (match.Success && (config.ValidationFunction?.Invoke(match.Value) ?? true))
         {
             return match.Value;
         }


### PR DESCRIPTION
Hi, I had a crash while trying to run this without a `ValidationFunction` in the `PatternConfig`, even though it defaults to null.

If `ValidationFunction` is null we will bypass it now.