### PR TITLE
feat(android): add 16 KB page size support

### DIFF
--- a/samples/Plugin.Maui.Feature.Sample/MainPage.xaml.cs
+++ b/samples/Plugin.Maui.Feature.Sample/MainPage.xaml.cs
@@ -230,7 +230,7 @@ public partial class MainPage
             await Clipboard.SetTextAsync(plainText);
 
             // Optional: Show feedback to user
-            await DisplayAlert("Success", "Text copied to clipboard", "OK");
+            await DisplayAlertAsync("Success", "Text copied to clipboard", "OK");
         }
     }
 
@@ -266,7 +266,7 @@ public partial class MainPage
             }
             catch (Exception ex)
             {
-                await DisplayAlert("Error", $"Failed to enhance image: {ex.Message}", "OK");
+                await DisplayAlertAsync("Error", $"Failed to enhance image: {ex.Message}", "OK");
             }
             finally
             {
@@ -297,7 +297,7 @@ public partial class MainPage
         }
         else
         {
-            await DisplayAlert("Sorry", "Image capture is not supported on this device.", "OK");
+            await DisplayAlertAsync("Sorry", "Image capture is not supported on this device.", "OK");
         }
     }
 
@@ -317,17 +317,17 @@ public partial class MainPage
         }
         else
         {
-            await DisplayAlert("Sorry", "Image capture is not supported on this device.", "OK");
+            await DisplayAlertAsync("Sorry", "Image capture is not supported on this device.", "OK");
         }
     }
 
     private async void OpenFromFileBtn_Clicked(object sender, EventArgs e)
     {
-        var photo = await MediaPicker.Default.PickPhotoAsync();
+        var lsPhoto = await MediaPicker.Default.PickPhotosAsync(new MediaPickerOptions() { SelectionLimit = 1 });
 
-        if (photo != null)
+        if (lsPhoto != null && lsPhoto.Count != 0)
         {
-            var result = await ProcessPhoto(photo);
+            var result = await ProcessPhoto(lsPhoto.FirstOrDefault());
             ResultLbl.Text = result.AllText;
             NoImagePlaceholder.IsVisible = false;
         }
@@ -335,15 +335,15 @@ public partial class MainPage
 
     private async void OpenFromFileUseEventBtn_Clicked(object sender, EventArgs e)
     {
-        var photo = await MediaPicker.Default.PickPhotoAsync();
+        var lsPhoto = await MediaPicker.Default.PickPhotosAsync(new MediaPickerOptions() { SelectionLimit = 1 });
 
-        if (photo == null)
+        if (lsPhoto == null || lsPhoto.Count == 0)
         {
             return;
         }
 
         _ocr.RecognitionCompleted += OnRecognitionCompleted;
-        await StartProcessingPhoto(photo);
+        await StartProcessingPhoto(lsPhoto.FirstOrDefault());
     }
 
     private void OnRecognitionCompleted(object sender, OcrCompletedEventArgs e)
@@ -472,7 +472,7 @@ public partial class MainPage
             ThresholdType.BinaryInv, 15, 10);
 
         // 4. Morphological Open + Close to remove noise and fill gaps
-        using var morphKernel = CvInvoke.GetStructuringElement(ElementShape.Rectangle, new System.Drawing.Size(2, 2), new System.Drawing.Point(-1, -1));
+        using var morphKernel = CvInvoke.GetStructuringElement(MorphShapes.Rectangle, new System.Drawing.Size(2, 2), new System.Drawing.Point(-1, -1));
         CvInvoke.MorphologyEx(thresholded, thresholded, MorphOp.Open, morphKernel, new System.Drawing.Point(-1, -1), 1, BorderType.Reflect, new MCvScalar());
         CvInvoke.MorphologyEx(thresholded, thresholded, MorphOp.Close, morphKernel, new System.Drawing.Point(-1, -1), 1, BorderType.Reflect, new MCvScalar());
 

--- a/samples/Plugin.Maui.Feature.Sample/Plugin.Maui.OCR.Sample.csproj
+++ b/samples/Plugin.Maui.Feature.Sample/Plugin.Maui.OCR.Sample.csproj
@@ -73,7 +73,7 @@
     <PackageReference Include="Plugin.Toolkit.Fonts.MaterialIcons" Version="1.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-      <Version>1.8.8.1</Version>
+      <Version>1.8.9</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/samples/Plugin.Maui.Feature.Sample/Plugin.Maui.OCR.Sample.csproj
+++ b/samples/Plugin.Maui.Feature.Sample/Plugin.Maui.OCR.Sample.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst</TargetFrameworks>
+    <!--<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>-->
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
     <OutputType>Exe</OutputType>
     <RootNamespace>Plugin.Maui.OCR.Sample</RootNamespace>
     <UseMaui>true</UseMaui>
@@ -28,23 +28,23 @@
 
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
-    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">23.0</SupportedOSPlatformVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
     <TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
     <SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-ios'">
+  <PropertyGroup Condition="'$(TargetFramework)'=='net10.0-ios'">
     <CodesignKey>Apple Development: Created via API (BQQPP4HLY2)</CodesignKey>
     <CodesignProvision>VS: WildCard Development</CodesignProvision>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
     <MtouchDebug>True</MtouchDebug>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
     <MtouchDebug>True</MtouchDebug>
   </PropertyGroup>
 
@@ -67,13 +67,13 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Plugin.Maui.OCR\Plugin.Maui.OCR.csproj" />
-    <PackageReference Include="CommunityToolkit.Maui" Version="8.0.1" />
-    <PackageReference Include="Emgu.CV.runtime.maui.mini" Version="4.9.0.5494" />
+    <PackageReference Include="CommunityToolkit.Maui" Version="12.2.0" />
+    <PackageReference Include="Emgu.CV.runtime.maui.mini" Version="4.12.0.5764" />
     <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
     <PackageReference Include="Plugin.Toolkit.Fonts.MaterialIcons" Version="1.0.3" />
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
     <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">
-      <Version>1.7.0.2</Version>
+      <Version>1.8.8.1</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/samples/global.json
+++ b/samples/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "10.0.100-rc.1.25451.107",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/src/Plugin.Maui.OCR/Plugin.Maui.OCR.csproj
+++ b/src/Plugin.Maui.OCR/Plugin.Maui.OCR.csproj
@@ -141,7 +141,7 @@
     <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.2.3" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
     <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.2.3" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
     <PackageReference Include="Xamarin.Google.MLKit.TextRecognition" Version="116.0.1.5" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.8.1" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.9" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.8">

--- a/src/Plugin.Maui.OCR/Plugin.Maui.OCR.csproj
+++ b/src/Plugin.Maui.OCR/Plugin.Maui.OCR.csproj
@@ -1,9 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0-android;net8.0-ios;net8.0-maccatalyst;net8.0</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net8.0-windows10.0.19041.0</TargetFrameworks>
+    <TargetFrameworks>net10.0-ios;net10.0-maccatalyst;net10.0;net10.0-android36.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <!-- Uncomment to also build the tizen app. You will need to install tizen by following this: https://github.com/Samsung/Tizen.NET -->
-    <!-- <TargetFrameworks>$(TargetFrameworks);net8.0-tizen</TargetFrameworks> -->
+    <!-- <TargetFrameworks>$(TargetFrameworks);net10.0-tizen</TargetFrameworks> -->
     <SingleProject>true</SingleProject>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -54,43 +54,43 @@
       (WarningsAsErrors);NU1900;NU1901;NU1902;NU1903;NU1904
     </WarningsAsErrors>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-android|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-maccatalyst|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-windows10.0.19041.0|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-android|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-android|AnyCPU'">
     <DebugSymbols>false</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-ios|AnyCPU'">
     <DebugSymbols>false</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-maccatalyst|AnyCPU'">
     <DebugSymbols>false</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0|AnyCPU'">
     <DebugSymbols>false</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-windows10.0.19041.0|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0-windows10.0.19041.0|AnyCPU'">
     <DebugSymbols>false</DebugSymbols>
     <DebugType>portable</DebugType>
   </PropertyGroup>
@@ -137,11 +137,11 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.3.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-    <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.3.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-    <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.3.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-    <PackageReference Include="Xamarin.Google.MLKit.TextRecognition" Version="116.0.0.7" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
-    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.7.0.2" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.Camera2" Version="1.4.2.3" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.Lifecycle" Version="1.4.2.3" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+    <PackageReference Include="Xamarin.AndroidX.Camera.View" Version="1.4.2.3" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+    <PackageReference Include="Xamarin.Google.MLKit.TextRecognition" Version="116.0.1.5" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
+    <PackageReference Include="Xamarin.AndroidX.Fragment.Ktx" Version="1.8.8.1" Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'" />
   </ItemGroup>
   <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
     <PackageReference Include="Roslynator.Analyzers" Version="4.12.8">


### PR DESCRIPTION
Google has announced a Play requirement: apps targeting Android 15+ must support 16 KiB memory page sizes (effective November 1, 2025). This change aligns apps with newer devices and toolchains and avoids install/runtime failures on 16 KiB devices. (https://developer.android.com/guide/practices/page-sizes)


CHANGELOG
- 16 KB page-size support, update NuGets for .NET 10 (16 KB page-size included in .NET 10)
- refactor: replace obsolete APIs