### PR TITLE
(iOS) Set AllText property to the joined lines list after looping.

### DIFF
--- a/src/Plugin.Maui.OCR/OcrImplementation.macios.cs
+++ b/src/Plugin.Maui.OCR/OcrImplementation.macios.cs
@@ -79,7 +79,6 @@ class OcrImplementation : IOcrService
                 continue;
             }
 
-            ocrResult.AllText += " " + topCandidate.String;
             ocrResult.Lines.Add(topCandidate.String);
 
             if (!string.IsNullOrEmpty(topCandidate.String))
@@ -113,6 +112,15 @@ class OcrImplementation : IOcrService
                     Confidence = topCandidate.Confidence
                 }));
             }
+        }
+
+        if (ocrResult.Lines.Count > 0)
+        {
+            ocrResult.AllText = string.Join(" ", ocrResult.Lines);
+        }
+        else
+        {
+            ocrResult.AllText = null;
         }
 
         foreach (var match in options.PatternConfigs.Select(config => OcrPatternMatcher.ExtractPattern(ocrResult.AllText, config)).Where(match => !string.IsNullOrEmpty(match)))


### PR DESCRIPTION
String concatenation was causing an artificial space to be prepended to the AllText property on iOS.  AllText should be constructed from the Lines property using string.Join after the observations loop.